### PR TITLE
大佬，发现您的项目引入了org.apache.logging.log4j:log4j-core@2.7组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.example</groupId>
@@ -17,7 +15,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.7</version>
+            <version>2.13.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache Log4j2 < 2.15.0远程代码执行漏洞
缺陷组件：org.apache.logging.log4j:log4j-core@2.7
漏洞编号：CVE-2021-44228
漏洞描述：Apache log4j是java中常用的日志记录组件，攻击者发现在小于2.15.0的版本中存在远程代码执行漏洞。
漏洞原因：
由于log4j2默认支持JNDI在内的Lookup查找机制，当日志内容中包含${foo.bar}样式的内容时，会查找相应的值进行替换。因此当用户请求中的内容通过log4j作为日志内容记录时，攻击者可能通过恶意构造的内容，触发log4j的lookup方法，进而执行恶意代码。

影响范围：[2.4, 2.12.3)
最小修复版本：2.13.2
缺陷组件引入路径：org.example:java-learn@1.0-SNAPSHOT->org.apache.logging.log4j:log4j-core@2.7
```
另外我运行这个项目时，IDE的安全插件提示还有55个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pd206a